### PR TITLE
_clothing and _status_effects

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -139,7 +139,10 @@ Slimecrossing Armor
 /obj/item/clothing/suit/armor/heavy/adamantine/equipped(mob/living/carbon/human/user, slot) //Gives you a trait to prevent increasing speed.
 	. = ..()
 	if(slot == SLOT_WEAR_SUIT)
-		ADD_TRAIT(user, TRAIT_IMMUTABLE_SLOW, "immutableslow_[REF(src)]")
+		ADD_TRAIT(user, TRAIT_IMMUTABLE_SLOW, "immutableslow_[REF(src)]") //Adds trait to prevent increases in movespeed
+		user.unignore_slowdown("slimestatus") //Deletes the stable red trait on equip to prevent bypassing it
+	if(!(slot == SLOT_WEAR_SUIT))
+		REMOVE_TRAIT(user, TRAIT_IMMUTABLE_SLOW, "immutableslow_[REF(src)]") 
 
 /obj/structure/light_prism/spectral
 	name = "spectral light prism"

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -772,7 +772,8 @@ datum/status_effect/stabilized/blue/on_remove()
 	if(HAS_TRAIT(owner, TRAIT_IMMUTABLE_SLOW))
 		return ..()
 	else
-		owner.ignore_slowdown("slimestatus")
+		owner.ignore_slowdown("slimestatus") 
+		return ..()
 
 /datum/status_effect/stabilized/red/on_remove()
 	owner.unignore_slowdown("slimestatus")


### PR DESCRIPTION
Fixes a variety of bugs with the recent xenobio nerfs

Fixes Red Stable Cores not working at all
Fixes adamantine armor not removing the immutable_slow trait on unequipping
Fixes a way to bypass the adamantine armor slowdown (again)
